### PR TITLE
Add profiles zgw, objecten to objecten-api-celery

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -235,6 +235,10 @@ services:
     depends_on:
       objecten-api:
         condition: service_healthy
+    profiles:
+      - zgw
+      - objecten
+
 
   objecttypen-api:
     image: maykinmedia/objecttypes-api:3.0.2


### PR DESCRIPTION
`docker compose --profile gzac up` currently fails because it includes `objecten-api-celery`, which it should not.